### PR TITLE
Fix breakpoint won't hit at one line function issue

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -30869,7 +30869,8 @@ static __exception int resolve_variables(JSContext *ctx, JSFunctionDef *s)
     next: ;
     }
 
-    line_num = 0; /* avoid warning */
+    /* init with function start line to ensure generate a valid last line for one-line function */
+    line_num = s->line_num;
     for (pos = 0; pos < bc_len; pos = pos_next) {
         op = bc_buf[pos];
         len = opcode_info[op].size;


### PR DESCRIPTION
In commit ab7e692, add some code to push last line num when function end.
code as this:

line = line_num + 1
dbuf_putc(&bc_out, OP_line_num);
dbuf_put_u32(&bc_out, line_num);

it means that if function end at line 50, add line 51 to the function's
bytecode array.
But if the function has only one line, no OP_line_num is found and
line_num will be it's initialize value, it 0, we want it to be the
function start line.

So just replace the
line_num = 0
to
line_num = s->line_num

Signed-off-by: pengyaozong <pengyaozong@xiaomi.com>